### PR TITLE
Pin action versions for blog and YouTube workflows

### DIFF
--- a/.github/workflows/blog-post-workflow.yml
+++ b/.github/workflows/blog-post-workflow.yml
@@ -3,12 +3,17 @@ on:
   schedule: # Run workflow automatically
     - cron: '0 * * * *' # Runs every hour, on the hour
   workflow_dispatch: # Run workflow manually (without waiting for the cron to be called), through the Github Actions Workflow page directly
+permissions:
+  contents: write
 jobs:
   update-readme-with-blog:
     name: Update this repo's README with latest blog posts
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: gautamkrishnar/blog-post-workflow@master
+      - uses: actions/checkout@v3
+      - uses: gautamkrishnar/blog-post-workflow@db6497e3ae83b3e837e6ed98c20da4f7e8b494f8
         with:
           feed_list: "https://syedmustafaimam.com/blog/feed/"
+          max_post_count: 5
+          readme_path: "README.md"
+

--- a/.github/workflows/youtube-workflow.yml
+++ b/.github/workflows/youtube-workflow.yml
@@ -4,14 +4,18 @@ on:
     # Runs every hour
     - cron: '0 * * * *'
   workflow_dispatch:
-
+permissions:
+  contents: write
 jobs:
   update-readme-with-youtube:
     name: Update this repo's README with latest videos from YouTube
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: gautamkrishnar/blog-post-workflow@master
+      - uses: actions/checkout@v3
+      - uses: gautamkrishnar/blog-post-workflow@db6497e3ae83b3e837e6ed98c20da4f7e8b494f8
         with:
           comment_tag_name: "YOUTUBE"
           feed_list: "https://www.youtube.com/feeds/videos.xml?channel_id=UCqHoTWr15EI3gPv5CyaREtw"
+          max_post_count: 5
+          readme_path: "README.md"
+


### PR DESCRIPTION
## Summary
- pin `actions/checkout` to v3 for blog and YouTube workflows
- pin `gautamkrishnar/blog-post-workflow` to a specific commit
- configure workflows to update README with latest posts and videos

## Testing
- `act -l` *(fails: couldn't get a valid docker connection)*

------
https://chatgpt.com/codex/tasks/task_b_68c812ced4788328af0d989a23337415